### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/GalacticDynamics/dataclassish/security/code-scanning/6](https://github.com/GalacticDynamics/dataclassish/security/code-scanning/6)

The best fix is to explicitly add a `permissions` key, restricting permissions for all jobs in the workflow (applies workflow-wide by default). Since the jobs here are mostly performing code checkout, installing dependencies, and running pre-commit/lint/tests (none of which require write permissions to the repository), the minimal permission required is `contents: read`. This should be placed near the top of the workflow, immediately after the `name` or `on` sections (conventionally after `name` but before `on`), so all jobs inherit it. No other methods, imports, or code changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
