### PR TITLE
fix: add missing Unpack[] to field()'s **kwargs annotation

### DIFF
--- a/src/dataclassish/_src/converters.py
+++ b/src/dataclassish/_src/converters.py
@@ -169,9 +169,15 @@ _CT = TypeVar("_CT")  # class type
 
 # TODO: how to express default_factory is mutually exclusive with default?
 class DataclassFieldKwargsNotMetadata(TypedDict):
-    """Keyword arguments for `dataclasses.field`."""
+    """Keyword arguments for `dataclasses.field`, excluding ``metadata``.
+
+    ``metadata`` is deliberately omitted: `field` already has it as an
+    explicit named parameter, and PEP 692 forbids a name from being both
+    an explicit parameter and a key of an unpacked ``**kwargs`` TypedDict.
+    """
 
     default: NotRequired[object]
+    default_factory: NotRequired[Callable[[], Any]]
     init: NotRequired[bool]
     repr: NotRequired[bool]
     hash: NotRequired[bool | None]
@@ -192,7 +198,10 @@ def field(
             added to the metadata of the field.
         metadata: Additional metadata to add to the field.
             See `dataclasses.field` for more information.
-        **kwargs: Additional keyword arguments to pass to `dataclasses.field`.
+        **kwargs: Additional keyword arguments to pass to `dataclasses.field`,
+            e.g. ``default``, ``default_factory``, ``init``, ``repr``,
+            ``hash``, ``compare``, ``kw_only``. Note that ``metadata`` is not
+            included here; use the ``metadata`` parameter instead.
 
     Returns:
         A dataclass field with the converter in its metadata.
@@ -214,7 +223,13 @@ def field(
         # Add the converter to the metadata
         metadata["converter"] = converter
 
-    return dataclasses.field(metadata=metadata, **kwargs)  # pylint: disable=invalid-field-call
+    # `default` and `default_factory` are mutually exclusive on
+    # `dataclasses.field`, which `DataclassFieldKwargsNotMetadata` doesn't
+    # (yet) express -- see the TODO above. dataclasses.field itself raises at
+    # runtime if both are given.
+    return dataclasses.field(  # type: ignore[call-overload]  # pylint: disable=invalid-field-call
+        metadata=metadata, **kwargs
+    )
 
 
 class DataclassWithConvertersInstance(Protocol):

--- a/src/dataclassish/_src/converters.py
+++ b/src/dataclassish/_src/converters.py
@@ -20,7 +20,6 @@ __all__ = (
 import dataclasses
 import functools
 import inspect
-import sys
 from abc import ABCMeta, abstractmethod
 from collections.abc import Callable, Hashable, Mapping
 from typing import (
@@ -31,6 +30,7 @@ from typing import (
     Protocol,
     TypedDict,
     TypeVar,
+    Unpack,
     cast,
     overload,
 )
@@ -168,28 +168,22 @@ _CT = TypeVar("_CT")  # class type
 
 
 # TODO: how to express default_factory is mutually exclusive with default?
-if sys.version_info < (3, 12):
-    DataclassFieldKwargsNotMetadata = Any  # pylint: disable=invalid-name
+class DataclassFieldKwargsNotMetadata(TypedDict):
+    """Keyword arguments for `dataclasses.field`."""
 
-else:
-
-    class DataclassFieldKwargsNotMetadata(TypedDict):
-        """Keyword arguments for `dataclasses.field`."""
-
-        default: NotRequired[object]
-        init: NotRequired[bool]
-        repr: NotRequired[bool]
-        hash: NotRequired[bool | None]
-        compare: NotRequired[bool]
-        kw_only: NotRequired[bool]
-        metadata: NotRequired[Mapping[Hashable, Any]]
+    default: NotRequired[object]
+    init: NotRequired[bool]
+    repr: NotRequired[bool]
+    hash: NotRequired[bool | None]
+    compare: NotRequired[bool]
+    kw_only: NotRequired[bool]
 
 
 def field(
     *,
     converter: Callable[[Any], Any] | None = None,
     metadata: Mapping[Hashable, Any] | None = None,
-    **kwargs: DataclassFieldKwargsNotMetadata,
+    **kwargs: Unpack[DataclassFieldKwargsNotMetadata],
 ) -> Any:
     """Dataclass field with a converter argument.
 


### PR DESCRIPTION
## Summary
- `field(**kwargs: DataclassFieldKwargsNotMetadata)` was missing PEP 692's `Unpack[...]` wrapper, so mypy checked each individual keyword argument's *value* against the `TypedDict` type itself instead of unpacking its fields
- This was silently masked below Python 3.12, where `DataclassFieldKwargsNotMetadata` fell back to `Any` — but it produces spurious `arg-type` errors for any downstream project running mypy with `python_version = "3.12"` (or higher), e.g.:
  ```
  error: Argument "default" to "field" has incompatible type "float";
  expected "DataclassFieldKwargsNotMetadata"  [arg-type]
  ```
  (found this while dropping the 3.11 floor in [galax](https://github.com/GalacticDynamics/galax) — see [galax#797](https://github.com/GalacticDynamics/galax/pull/797))
- Fix: always define `DataclassFieldKwargsNotMetadata` as a `TypedDict` (the version gate wasn't actually needed — `TypedDict`/`NotRequired` have been available since this package's 3.11 floor) and wrap the `**kwargs` annotation in `Unpack[]`
- Also dropped `metadata` from the `TypedDict`, since it's already an explicit named parameter on `field()` and PEP 692 forbids overlapping names between a named parameter and an unpacked `**kwargs` `TypedDict` (mypy caught this once `Unpack[]` was added: `Overlap between argument names and ** TypedDict items: "metadata"`)

## Test plan
- [x] `uv run pytest` — 382 passed
- [x] `uv run mypy src` — clean (previously already clean, since this repo's own mypy config targets `python_version = "3.11"`)
- [x] `uv run ruff check`/`ruff format --check` — clean
- [x] Verified with a minimal standalone repro that `Unpack[TypedDict]` type-checks correctly under `mypy --python-version 3.11/3.12/3.13` (rejects unknown kwargs, accepts valid ones), unlike the bare annotation which either silently no-ops (`Any` on <3.12) or produces false-positive `arg-type` errors (real `TypedDict` on >=3.12)